### PR TITLE
New difficulty quick fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -902,6 +902,8 @@ unsigned int static GetNextWorkRequired(const CBlockIndex* pindexLast, const CBl
         return pindexLast->nBits;
     }
 
+    if (pindexLast->nHeight > COINFIX2_BLOCK) { nReTargetHistoryFact = 1;} //new coinfix only look at current block and previous
+    
     // Litecoin: This fixes an issue where a 51% attack can change difficulty at will.
     // Go back the full period unless it's the first retarget after genesis. Code courtesy of Art Forz
     int blockstogoback = nInterval-1;
@@ -911,6 +913,7 @@ unsigned int static GetNextWorkRequired(const CBlockIndex* pindexLast, const CBl
         blockstogoback = nReTargetHistoryFact * nInterval;
     }
 
+    
     // Go back by what we want to be nReTargetHistoryFact*nInterval blocks
     const CBlockIndex* pindexFirst = pindexLast;
     for (int i = 0; pindexFirst && i < blockstogoback; i++)
@@ -925,11 +928,20 @@ unsigned int static GetNextWorkRequired(const CBlockIndex* pindexLast, const CBl
     else
         nActualTimespan = pindexLast->GetBlockTime() - pindexFirst->GetBlockTime();
     printf("  nActualTimespan = %"PRI64d"  before bounds\n", nActualTimespan);
-    if (nActualTimespan < nTargetTimespan/4)
-        nActualTimespan = nTargetTimespan/4;
-    if (nActualTimespan > nTargetTimespan*4)
-        nActualTimespan = nTargetTimespan*4;
-
+    
+    if (pindexLast->nHeight > COINFIX2_BLOCK){
+        if (nActualTimespan > nTargetTimespan*2) //if more than 2* the target set minimum difficulty
+            return nProofOfWorkLimit;
+          
+        if (nActualTimespan < nTargetTimespan/2) //if less than half the target 2* difficulty
+            nActualTimespan = nTargetTimespan/2;
+    }
+    else{
+        if (nActualTimespan < nTargetTimespan/4)
+            nActualTimespan = nTargetTimespan/4;
+        if (nActualTimespan > nTargetTimespan*4) 
+            nActualTimespan = nTargetTimespan*4;
+    }
     // Retarget
     CBigNum bnNew;
     bnNew.SetCompact(pindexLast->nBits);

--- a/src/main.h
+++ b/src/main.h
@@ -31,6 +31,7 @@ class CNode;
 // Thanks: https://bitcointalk.org/index.php?topic=182430.msg1904506#msg1904506
 // activated: after block 15000 for all following diff retargeting events
 #define COINFIX1_BLOCK  (15000)
+#define COINFIX2_BLOCK  (21950)
 
 // for now, we leave the block size at 1 MB, meaning we support roughly 2400 transactions
 // per block, which means about 160 tps


### PR DESCRIPTION
If average of last 2 block times is more than double the target set
difficulty back to minimum.
If average of last 2 block times is less than half the target double the
difficulty

Takes effect at block 21950
